### PR TITLE
Sets default caching TTL to 300 seconds

### DIFF
--- a/toonapilib/configuration.py
+++ b/toonapilib/configuration.py
@@ -4,7 +4,7 @@
 """A place to store the configuration."""
 
 
-STATE_CACHING_SECONDS = 30
+STATE_CACHING_SECONDS = 300
 REQUEST_TIMEOUT = 9
 
 STATES = {0: 'Comfort',


### PR DESCRIPTION
This PR changes the TTL for caching stats to a more sane default: 300 seconds.

Reasoning behind this:

https://developer.toon.eu/developer-journey

> you are allowed to consume 60 calls per minute and 500 calls per day per display

I've been contacted by Quby regarding this issue and they would highly appriciate action around this part.

I'm looking into a solution on the Home Assistant side of things as well, nevertheless, from a implementation / quick win perspective, this is the fastest way to prevent further issues.

Ref: #31 